### PR TITLE
promote: champion v8

### DIFF
--- a/gitops/kserve-inference.yaml
+++ b/gitops/kserve-inference.yaml
@@ -22,7 +22,7 @@ spec:
       # the `promote` DAG step (argo-workflow.yaml, promote_model.py) resolves
       # that alias and pushes the resulting storageUri here. Don't hand-edit —
       # it'll be overwritten on the next promote run.
-      storageUri: "s3://mlflow-artifacts/mlflow/1/models/m-a27c2eaef0a04c7098aafe2f767d3d33/artifacts"
+      storageUri: "s3://mlflow-artifacts/mlflow/1/models/m-1d4492894368470ebc6c58f901055392/artifacts"
       resources:
         requests:
           cpu: "100m"


### PR DESCRIPTION
Automated promotion by the `promote` DAG step.

storageUri -> `s3://mlflow-artifacts/mlflow/1/models/m-1d4492894368470ebc6c58f901055392/artifacts`

Auto-merges once CI checks pass.