### PR TITLE
promote: champion v4

### DIFF
--- a/gitops/kserve-inference.yaml
+++ b/gitops/kserve-inference.yaml
@@ -22,7 +22,7 @@ spec:
       # the `promote` DAG step (argo-workflow.yaml, promote_model.py) resolves
       # that alias and pushes the resulting storageUri here. Don't hand-edit —
       # it'll be overwritten on the next promote run.
-      storageUri: "s3://mlflow-artifacts/mlflow/1/models/m-953d004447854202bc58c6966c376927/artifacts"
+      storageUri: "s3://mlflow-artifacts/mlflow/1/models/m-bd5a78c3613145ec8898ec70bd25c437/artifacts"
       resources:
         requests:
           cpu: "100m"


### PR DESCRIPTION
Automated promotion by the `promote` DAG step.

storageUri -> `s3://mlflow-artifacts/mlflow/1/models/m-bd5a78c3613145ec8898ec70bd25c437/artifacts`

Auto-merges once CI checks pass.